### PR TITLE
Fix Extract App for ownCloud 10.13

### DIFF
--- a/lib/Controller/ExtractionController.php
+++ b/lib/Controller/ExtractionController.php
@@ -148,9 +148,15 @@ class ExtractionController extends Controller {
 			$tmpPath = $appDirectory->getPath() . '/' . $archiveDir;
 			$extractTo = $appDirectory->getStorage()->getLocalFile($appDirectory->getInternalPath()) . '/' . $archiveDir;
 		} else {
+			$extractPath = $this->userId . '/files/' . $directory . '/' . $fileName;
+			try {
+				$appDirectory = $this->rootFolder->get($extractPath);
+			} catch (\OCP\Files\NotFoundException $e) {
+				$appDirectory = $this->rootFolder->newFolder($extractPath);
+			}
 			$tmpPath = "";
 		}
-		
+
 		switch ($type) {
 			case 'zip':
 				$response = $this->extractionService->extractZip($file, $fileName, $extractTo);


### PR DESCRIPTION
Extract app doesn't work with OC10.13, where I got an exception.

```
"message":"Exception: {\"Exception\":\"UnexpectedValueException\",\"Message\":\"RecursiveDirectoryIterator::__construct(\\\/data\\\/users\\\/tomw\\\/extract\\\/lumise203): failed to open dir: No such file or directory\",\"Code\":0,\"Trace\":\"#0 \\\/var\\\/www\\\/owncloud\\\/apps\\\/extract\\\/lib\\\/Controller\\\/ExtractionController.php(91): RecursiveDirectoryIterator->__construct()\\n#1 \\\/var\\\/www\\\/owncloud\\\/apps\\\/extract\\\/lib\\\/Controller\\\/ExtractionController.php(175): OCA\\\\Extract\\\\Controller\\\\ExtractionController->postExtract()\\n#2 \\\/var\\\/www\\\/owncloud\\\/lib\\\/private\\\/AppFramework\\\/Http\\\/Dispatcher.php(169): OCA\\\\Extract\\\\Controller\\\\ExtractionController->extract()\\n#3 \\\/var\\\/www\\\/owncloud\\\/lib\\\/private\\\/AppFramework\\\/Http\\\/Dispatcher.php(89): OC\\\\AppFramework\\\\Http\\\\Dispatcher->executeController()\\n#4 \\\/var\\\/www\\\/owncloud\\\/lib\\\/private\\\/AppFramework\\\/App.php(99): OC\\\\AppFramework\\\\Http\\\\Dispatcher->dispatch()\\n#5 \\\/var\\\/www\\\/owncloud\\\/lib\\\/private\\\/AppFramework\\\/Routing\\\/RouteActionHandler.php(47): OC\\\\AppFramework\\\\App::main()\\n#6 \\\/var\\\/www\\\/owncloud\\\/lib\\\/private\\\/Route\\\/Router.php(344): OC\\\\AppFramework\\\\Routing\\\\RouteActionHandler->__invoke()\\n#7 \\\/var\\\/www\\\/owncloud\\\/lib\\\/base.php(916): OC\\\\Route\\\\Router->match()\\n#8 \\\/var\\\/www\\\/owncloud\\\/index.php(54): OC::handleRequest()\\n#9 {main}\",\"File\":\"\\\/var\\\/www\\\/owncloud\\\/apps\\\/extract\\\/lib\\\/Controller\\\/ExtractionController.php\",\"Line\":91}"
```

Fixed by creating the destination folder by forehand, before extraction.
